### PR TITLE
chore: align staged publish workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install dependencies
       run: npm install
     - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+      - 'v*.*.*-*'
 permissions:
   contents: write
   id-token: write
@@ -15,15 +16,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '24.x'
+          node-version: '26.x'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
-          always-auth: true
 
       - name: Install dependencies
         run: npm ci
@@ -34,10 +34,24 @@ jobs:
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
 
-      - name: Publish to npm
-        run: npm publish --provenance --access public
+      - name: Determine npm tag and release type
+        id: release-info
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" =~ -.*$ ]]; then
+            echo "npm_tag=next" >> $GITHUB_OUTPUT
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "npm_tag=latest" >> $GITHUB_OUTPUT
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Stage publish to npm
+        run: npm stage publish --provenance --access public --tag ${{ steps.release-info.outputs.npm_tag }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+          prerelease: true
+          make_latest: false


### PR DESCRIPTION
Align release workflow with the ctrf-js staged publish template and normalize actions/checkout and actions/setup-node to @v6 in main workflow where present.